### PR TITLE
Add prebuilt binary releases via GoReleaser (secret-free)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # required for the built-in GITHUB_TOKEN to create the release
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so the changelog can be built
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ go.work.sum
 # Local CLI binary
 magicmix
 
+# GoReleaser build output
+dist/
+
 # Generated playlist output (written next to the input)
 *_magicmix.csv
 *_keep.csv

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,60 @@
+# GoReleaser configuration — https://goreleaser.com
+# Builds cross-platform binaries and attaches them to a GitHub Release on tag push.
+# Secret-free: the release workflow uses the automatic GITHUB_TOKEN.
+version: 2
+
+project_name: magicmix
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: magicmix
+    main: ./cmd/magicmix
+    binary: magicmix
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      # Windows on ARM is niche and untested; skip it.
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - id: magicmix
+    formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "Merge pull request"
+      - "Merge branch"
+
+release:
+  draft: false
+  prerelease: auto

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install test clean fmt vet tidy deps lint modern modern-check ci help
+.PHONY: build install test clean fmt vet tidy deps lint modern modern-check ci snapshot help
 
 default: build
 
@@ -39,5 +39,8 @@ modern: ## Fix modern Go code issues
 
 ci: tidy build test vet modern-check ## Run all CI checks locally
 
+snapshot: ## Build a local release snapshot into dist/ (no publish)
+	@go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean --skip=publish
+
 clean: ## Clean build artifacts
-	@rm -rf bin/ coverage.out coverage.html
+	@rm -rf bin/ dist/ coverage.out coverage.html

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ key, tempo, mood, and energy flow well — and drops the few that don't fit.
 
 ## Install
 
+Prebuilt binaries for macOS, Linux, and Windows are attached to each
+[release](https://github.com/YakDriver/magicmix/releases) — download the archive for
+your platform, extract, and put `magicmix` on your `PATH`.
+
+> On macOS, a downloaded binary is quarantined by Gatekeeper. Clear it with
+> `xattr -d com.apple.quarantine ./magicmix` (or right-click → Open once).
+
+Or install from source with Go:
+
 ```bash
 go install github.com/YakDriver/magicmix/cmd/magicmix@latest
 ```


### PR DESCRIPTION
## Summary
Adds prebuilt binary releases so users don't need Go installed. On pushing a `v*` tag, GitHub Actions cross-compiles `magicmix` and attaches archives + `checksums.txt` to the GitHub Release. **Secret-free** — it uses only the automatic `GITHUB_TOKEN`.

- **`.goreleaser.yaml`** — builds macOS/Linux/Windows for amd64 + arm64 (Windows arm64 skipped as untested), `CGO_ENABLED=0`, `-trimpath`, stripped. Archives are `tar.gz` (`zip` on Windows) and bundle `README.md` + `LICENSE`.
- **`.github/workflows/release.yml`** — tag-triggered, `contents: write`, runs GoReleaser via the official action.
- **`make snapshot`** — build a local release into `dist/` (no publish) for testing.
- **README** — documents downloading prebuilt binaries and the macOS Gatekeeper/quarantine note; `go install` kept as the from-source path.
- **`.gitignore`** — ignores `dist/`.

## Verification
- `goreleaser check` passes; a full `--snapshot` build produced all five archives + `checksums.txt`, each archive contains `magicmix` + `README.md` + `LICENSE`, and the built binary runs (`--list-strategies`).
- `go build`/`go test ./...` green; `go.mod`/`go.sum` unchanged.

## How to cut the first release (after merge)
```bash
git checkout main && git pull
git tag v0.1.0
git push origin v0.1.0
```
The workflow builds the release and attaches the binaries. Tagging also makes `go install ...@latest` resolve to a stable version.

## Not included (would need creds — intentionally skipped)
macOS signing/notarization (Apple Developer account), Homebrew tap (PAT), Docker/Scoop/etc. Unsigned macOS binaries hit Gatekeeper; the README explains the one-line `xattr` workaround.
