### PR TITLE
Fix .gitignore hiding cmd/magicmix entrypoint (unblocks releases)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,8 @@ go.work.sum
 .gocache/
 .gomodcache/
 
-# Local CLI binary
-magicmix
+# Local CLI binary (repo-root build output only; must not match cmd/magicmix/)
+/magicmix
 
 # GoReleaser build output
 dist/

--- a/cmd/magicmix/main.go
+++ b/cmd/magicmix/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"log"
+
+	"github.com/YakDriver/magicmix/internal/cli"
+)
+
+func main() {
+	if err := cli.Run(); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
The unrooted `magicmix` gitignore pattern (intended for the repo-root build binary) also matched the `cmd/magicmix/` directory, so `cmd/magicmix/main.go` was never committed.

Local builds worked only because the file was on disk. A clean checkout — CI, `go install github.com/YakDriver/magicmix/cmd/magicmix@latest`, and GoReleaser — had no entrypoint, which is why the v0.1.0 release build failed with `stat cmd/magicmix: no such file or directory`.

Fix: root the pattern to `/magicmix` (repo-root binary only) and commit the entrypoint. Verified `git check-ignore` no longer matches `cmd/magicmix/main.go`, a root `magicmix` binary is still ignored, and `git ls-files cmd/` now lists `cmd/magicmix/main.go`.

After this merges, re-cut the tag: `git tag -a v0.1.0 -m "magicmix v0.1.0" && git push origin v0.1.0`.